### PR TITLE
Use boolean superType Syntax in nodeTypes.yaml

### DIFF
--- a/Configuration/NodeTypes.yaml
+++ b/Configuration/NodeTypes.yaml
@@ -85,7 +85,8 @@
 
 
 'Flowpack.SimpleSearch.ContentRepositoryAdaptor:Search':
-  superTypes: ['TYPO3.Neos:Content']
+  superTypes: 
+    'TYPO3.Neos:Content': TRUE
   ui:
     label: 'Search'
     icon: 'icon-search'


### PR DESCRIPTION
The syntax for superTypes was changed with Neos 2.0 and the old one is deprecated now. In a release that no longer supports Neos 1.x this should be updated.
